### PR TITLE
Change properties to Object

### DIFF
--- a/test/bad/1.js
+++ b/test/bad/1.js
@@ -5,7 +5,7 @@ import type {
 } from '../../types.js';
 
 
-function enumeratePostions(collection: GeoJSONFeatureCollection):Array<[number, number]> {
+function enumeratePostions(collection: GeoJSONFeatureCollection<*>):Array<[number, number]> {
   const r: Array<[number, number]> = [];
   collection.features.forEach(feature => {
     const geometry = feature.geometry;

--- a/test/good/1.js
+++ b/test/good/1.js
@@ -5,7 +5,7 @@ import type {
 } from '../../types.js';
 
 
-function enumeratePostions(collection: GeoJSONFeatureCollection):Array<[number, number]> {
+function enumeratePostions(collection: GeoJSONFeatureCollection<*>):Array<[number, number]> {
   const r: Array<[number, number]> = [];
   collection.features.forEach(feature => {
     const geometry = feature.geometry;

--- a/types.js
+++ b/types.js
@@ -117,10 +117,10 @@ export type GeometryCollection = {
  * http://geojson.org/geojson-spec.html#geometry-collection
  */
 
-export type Feature = { // TODO make generic
+export type Feature<T> = {
   type: 'Feature',
   geometry: ?GeometryObject,
-  properties: ?Object,
+  properties: ?T,
   id?: number | string // is not specified, but nothing else makes sense
 };
 

--- a/types.js
+++ b/types.js
@@ -11,10 +11,10 @@ assert(false, `geojson-flow shouldn't be used at runtime`);
  * http://geojson.org/geojson-spec.html#geojson-objects
  */
 
-export type GeoJSONObject =
+export type GeoJSONObject<T> =
   | GeometryObject
-  | Feature
-  | FeatureCollection;
+  | Feature<T>
+  | FeatureCollection<T>;
 
 type Common = { // TODO inline
   crs?: ?CRS,
@@ -129,9 +129,9 @@ export type Feature<T> = {
  * http://geojson.org/geojson-spec.html#feature-collection-objects
  */
 
-export type FeatureCollection = { // TODO make generic
+export type FeatureCollection<T> = {
   type: 'FeatureCollection',
-  features: Array<Feature>
+  features: Array<Feature<T>>
 };
 
 /**

--- a/types.js
+++ b/types.js
@@ -120,7 +120,7 @@ export type GeometryCollection = {
 export type Feature = { // TODO make generic
   type: 'Feature',
   geometry: ?GeometryObject,
-  properties: ?{},
+  properties: ?Object,
   id?: number | string // is not specified, but nothing else makes sense
 };
 


### PR DESCRIPTION
Currently the `properties` field of a `Feature` has to be an empty object. Now it could be an arbitrary object.